### PR TITLE
get_schema_view() now accepts list instead of tuple (drf-yasg 1.20)

### DIFF
--- a/drf_yasg-stubs/views.pyi
+++ b/drf_yasg-stubs/views.pyi
@@ -40,6 +40,6 @@ def get_schema_view(
     public: bool = ...,
     validators: Optional[List[str]] = ...,
     generator_class: Optional[Type[OpenAPISchemaGenerator]] = ...,
-    authentication_classes: Optional[Tuple[Type[BaseAuthentication]]] = ...,
-    permission_classes: Optional[Tuple[Type[BasePermission]]] = ...,
+    authentication_classes: Optional[List[Type[BaseAuthentication]]] = ...,
+    permission_classes: Optional[List[Type[BasePermission]]] = ...,
 ) -> _SchemaView: ...


### PR DESCRIPTION
Upstream commits:
* https://github.com/axnsan12/drf-yasg/commit/b99306f71c6a5779b62189df7d9c1f5ea1c794ef
* https://github.com/axnsan12/drf-yasg/commit/c14a4d48f3ef7d4363a4e0898d9325c8c451e1a3
