### PR TITLE
Fix annotation for swagger_auto_schema/request_body

### DIFF
--- a/drf_yasg-stubs/utils.pyi
+++ b/drf_yasg-stubs/utils.pyi
@@ -23,7 +23,7 @@ def swagger_auto_schema(
     method: Optional[str] = ...,
     methods: Optional[List[str]] = ...,
     auto_schema: Optional[Type] = ...,
-    request_body: Optional[Union[_SchemaOrRef, _SerializerOrClass]] = ...,
+    request_body: Optional[Union[_SchemaOrRef, _SerializerOrClass, Type[no_body]]] = ...,
     query_serializer: Optional[_SerializerOrClass] = ...,
     manual_parameters: Optional[List[openapi.Parameter]] = ...,
     operation_id: Optional[str] = ...,


### PR DESCRIPTION
Hello, I ran into a mypy error when trying to pass the [`no_body`](https://drf-yasg.readthedocs.io/en/stable/drf_yasg.html#drf_yasg.utils.no_body) sentinel value to the `request_body` parameter of `swagger_auto_schema`.

```
error: Argument "request_body" to "swagger_auto_schema" has incompatible type "Type[no_body]"; expected "Union[Schema, SchemaRef, Serializer[Any], Type[Serializer[Any]], None]"
```

Adding `Type[no_body]` to the union fixes the issue for me.

Let me know if there's anything amiss, I'm not yet familiar with the type stub system. Thank you !